### PR TITLE
Forcing shutdown of the camelot-test-maven-plugin.

### DIFF
--- a/camelot-extensions/src/main/java/ru/yandex/qatools/camelot/maven/service/CamelotJettyRunner.java
+++ b/camelot-extensions/src/main/java/ru/yandex/qatools/camelot/maven/service/CamelotJettyRunner.java
@@ -81,7 +81,7 @@ public class CamelotJettyRunner {
         context.setParentLoaderPriority(true);
         context.setClassLoader(createWebAppClassLoader(context));
 
-        server.setHandler(createHandlersForServer(server, context));
+        server.setHandler(createHandlersForServer(context));
         server.start();
 
         if (waitFor) {
@@ -122,15 +122,14 @@ public class CamelotJettyRunner {
     /**
      * Create {@link org.eclipse.jetty.server.handler.HandlerList} for given jetty server and web application context
      *
-     * @param server  specified {@link org.eclipse.jetty.server.Server}
      * @param context specified web application context
      * @return created handlers
      */
-    public static HandlerList createHandlersForServer(Server server, WebAppContext context) {
+    public static HandlerList createHandlersForServer(WebAppContext context) {
         HandlerList handlers = new HandlerList();
-        final ShutdownHandler shutdownHandler = new ShutdownHandler(server, SHUTDOWN_PASSWORD);
+        final ShutdownHandler shutdownHandler = new JettyKillHandler(SHUTDOWN_PASSWORD, true, true);
         shutdownHandler.setExitJvm(true);
-        handlers.setHandlers(new Handler[]{shutdownHandler, context});
+        handlers.setHandlers(new Handler[]{context, shutdownHandler});
         return handlers;
     }
 

--- a/camelot-extensions/src/main/java/ru/yandex/qatools/camelot/maven/service/JettyKillHandler.java
+++ b/camelot-extensions/src/main/java/ru/yandex/qatools/camelot/maven/service/JettyKillHandler.java
@@ -1,0 +1,26 @@
+package ru.yandex.qatools.camelot.maven.service;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ShutdownHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static java.lang.Runtime.getRuntime;
+
+/**
+ * @author smecsia
+ */
+public class JettyKillHandler extends ShutdownHandler {
+    public JettyKillHandler(String shutdownToken, boolean exitJVM, boolean sendShutdownAtStart) {
+        super(shutdownToken, exitJVM, sendShutdownAtStart);
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        super.handle(target, baseRequest, request, response);
+        getRuntime().halt(0);
+    }
+}

--- a/camelot-extensions/src/main/java/ru/yandex/qatools/camelot/maven/utils/CamelotRunnerUtils.java
+++ b/camelot-extensions/src/main/java/ru/yandex/qatools/camelot/maven/utils/CamelotRunnerUtils.java
@@ -3,11 +3,6 @@ package ru.yandex.qatools.camelot.maven.utils;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.Executor;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.server.handler.ShutdownHandler;
-import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,7 +11,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -35,7 +29,7 @@ public final class CamelotRunnerUtils {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(CamelotRunnerUtils.class);
 
-    public static final String WAITFOR_TOKEN = "Started SelectChannelConnector";
+    public static final String WAITFOR_TOKEN = "Started ServerConnector";
 
     public static final String MANIFEST_VERSION = "1.0";
 


### PR DESCRIPTION
Jetty does not shutdown normally. We have to ask it more polite.
