### PR TITLE
improve camelot-test/Matchers error message a bit

### DIFF
--- a/camelot-test/src/main/java/ru/yandex/qatools/camelot/test/Matchers.java
+++ b/camelot-test/src/main/java/ru/yandex/qatools/camelot/test/Matchers.java
@@ -27,7 +27,7 @@ public class Matchers {
         @Override
         public void describeTo(Description description) {
             description.appendText(String.format(
-                    "Storage containing not null object by key '%s'", key));
+                    "storage containing aggregator state by key '%s'", key));
         }
     }
 


### PR DESCRIPTION
Slight improvement for the case when this matcher is used with not() matcher.
Previously the error message would be: "Expected: not Storage containing not null object by key ...",
now it will be: "not storage containing aggregator state by key ..." which is a bit better looking.
