### PR TITLE
improve CI link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simplified scalable aggregation and processing framework built upon Apache Camel
 * [Documentation](https://github.com/camelot-framework/camelot/wiki)
 * [Examples](https://github.com/camelot-framework/camelot-sample)
 * [Issue Tracking](https://github.com/camelot-framework/camelot/issues?labels=&milestone=&page=1&state=open)
-* [CI](http://teamcity.qatools.ru/)
+* [CI](http://teamcity.qatools.ru/project.html?projectId=CamelotFramework)
 * [Releases and Changelog](https://github.com/camelot-framework/camelot/releases)
 
 ## Contact us


### PR DESCRIPTION
set it to http://teamcity.qatools.ru/project.html?projectId=CamelotFramework instead of just http://teamcity.qatools.ru/
