### PR TITLE
add impl parameter to @PluginComponent

### DIFF
--- a/camelot-api/src/main/java/ru/yandex/qatools/camelot/api/annotations/PluginComponent.java
+++ b/camelot-api/src/main/java/ru/yandex/qatools/camelot/api/annotations/PluginComponent.java
@@ -9,8 +9,11 @@ import java.lang.annotation.Target;
  * Annotation which is used for injection of custom plugin components
  *
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PluginComponent {
+
+    public Class impl() default Object.class;
 }

--- a/camelot-core/src/main/java/ru/yandex/qatools/camelot/core/impl/PluginContextInjectorImpl.java
+++ b/camelot-core/src/main/java/ru/yandex/qatools/camelot/core/impl/PluginContextInjectorImpl.java
@@ -27,6 +27,7 @@ import static ru.yandex.qatools.camelot.util.TypesUtil.*;
 
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
 public class PluginContextInjectorImpl<P> implements PluginContextInjector<P> {
     protected final static Logger LOGGER = LoggerFactory.getLogger(PluginContextInjectorImpl.class);
@@ -184,7 +185,8 @@ public class PluginContextInjectorImpl<P> implements PluginContextInjector<P> {
                     final Class<?> type = field.getType();
                     try {
                         if (!components.containsKey(type)) {
-                            final Object instance = type.newInstance();
+                            final Class defaultClass = info.impl;
+                            final Object instance = (defaultClass == Object.class ? type : defaultClass).newInstance();
                             performInjection(instance, context, exchange);
                             components.put(type, instance);
                         }
@@ -219,6 +221,7 @@ public class PluginContextInjectorImpl<P> implements PluginContextInjector<P> {
         public String id;
         public Object value;
         public String topic;
+        public Class impl;
 
         public <T extends Annotation> AnnotationInfo(T annotation) {
             try {
@@ -235,6 +238,11 @@ public class PluginContextInjectorImpl<P> implements PluginContextInjector<P> {
                 topic = (String) getAnnotationValue(annotation, "topic");
             } catch (Exception e) {
                 LOGGER.trace("Failed to get annotation field `topic` for " + annotation, e);
+            }
+            try {
+                impl = (Class) getAnnotationValue(annotation, "impl");
+            } catch (Exception e) {
+                LOGGER.trace("Failed to get annotation field `impl` for " + annotation, e);
             }
         }
     }

--- a/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/impl/InjectableInterface.java
+++ b/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/impl/InjectableInterface.java
@@ -1,0 +1,7 @@
+package ru.yandex.qatools.camelot.core.impl;
+
+/**
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
+ */
+public interface InjectableInterface {
+}

--- a/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/impl/InjectableInterfaceImpl.java
+++ b/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/impl/InjectableInterfaceImpl.java
@@ -1,0 +1,21 @@
+package ru.yandex.qatools.camelot.core.impl;
+
+import ru.yandex.qatools.camelot.api.EventProducer;
+import ru.yandex.qatools.camelot.api.Storage;
+import ru.yandex.qatools.camelot.api.annotations.Input;
+import ru.yandex.qatools.camelot.api.annotations.PluginStorage;
+import ru.yandex.qatools.camelot.core.plugins.AllSkippedAggregator;
+
+/**
+ * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
+ */
+public class InjectableInterfaceImpl implements InjectableInterface {
+
+    @Input
+    EventProducer input;
+
+    @PluginStorage(AllSkippedAggregator.class)
+    Storage otherPluginStorage;
+
+}

--- a/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/impl/PluginContextInjectorTest.java
+++ b/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/impl/PluginContextInjectorTest.java
@@ -23,12 +23,14 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
 @RunWith(CamelSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath*:camelot-core-context.xml", "classpath*:test-camelot-core-context.xml"})
 @SuppressWarnings("unchecked")
 @DirtiesContext(classMode = AFTER_CLASS)
 public class PluginContextInjectorTest {
+
     @Autowired
     ProcessingEngine processingEngine;
 
@@ -65,5 +67,8 @@ public class PluginContextInjectorTest {
         assertNotNull("Context must be injected", agg.injectableComponent);
         assertEquals("Context must be injected", agg.input1, agg.injectableComponent.input);
         assertEquals("Plugin storage must be injected", agg.storage1, agg.injectableComponent.otherPluginStorage);
+        assertNotNull("Context must be injected", agg.injectableInterface);
+        assertEquals("Context must be injected", agg.input1, ((InjectableInterfaceImpl) agg.injectableInterface).input);
+        assertEquals("Plugin storage must be injected", agg.storage1, ((InjectableInterfaceImpl) agg.injectableInterface).otherPluginStorage);
     }
 }

--- a/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/plugins/AggregatorWithContext.java
+++ b/camelot-core/src/test/java/ru/yandex/qatools/camelot/core/plugins/AggregatorWithContext.java
@@ -1,32 +1,13 @@
 package ru.yandex.qatools.camelot.core.plugins;
 
-import ru.yandex.qatools.camelot.api.AggregatorRepository;
-import ru.yandex.qatools.camelot.api.AppConfig;
-import ru.yandex.qatools.camelot.api.ClientMessageSender;
-import ru.yandex.qatools.camelot.api.EndpointListener;
-import ru.yandex.qatools.camelot.api.EventProducer;
-import ru.yandex.qatools.camelot.api.PluginInterop;
-import ru.yandex.qatools.camelot.api.PluginsInterop;
-import ru.yandex.qatools.camelot.api.Storage;
-import ru.yandex.qatools.camelot.api.annotations.Aggregate;
-import ru.yandex.qatools.camelot.api.annotations.AggregationKey;
-import ru.yandex.qatools.camelot.api.annotations.ClientSender;
-import ru.yandex.qatools.camelot.api.annotations.Config;
-import ru.yandex.qatools.camelot.api.annotations.ConfigValue;
-import ru.yandex.qatools.camelot.api.annotations.InjectHeader;
-import ru.yandex.qatools.camelot.api.annotations.InjectHeaders;
-import ru.yandex.qatools.camelot.api.annotations.Input;
-import ru.yandex.qatools.camelot.api.annotations.Listener;
-import ru.yandex.qatools.camelot.api.annotations.Output;
-import ru.yandex.qatools.camelot.api.annotations.Plugin;
-import ru.yandex.qatools.camelot.api.annotations.PluginComponent;
-import ru.yandex.qatools.camelot.api.annotations.PluginStorage;
-import ru.yandex.qatools.camelot.api.annotations.Plugins;
-import ru.yandex.qatools.camelot.api.annotations.Repository;
+import ru.yandex.qatools.camelot.api.*;
+import ru.yandex.qatools.camelot.api.annotations.*;
 import ru.yandex.qatools.camelot.core.beans.CounterState;
 import ru.yandex.qatools.camelot.core.beans.StopAggregatorWithTimer;
 import ru.yandex.qatools.camelot.core.beans.TestStarted;
 import ru.yandex.qatools.camelot.core.impl.InjectableComponent;
+import ru.yandex.qatools.camelot.core.impl.InjectableInterface;
+import ru.yandex.qatools.camelot.core.impl.InjectableInterfaceImpl;
 import ru.yandex.qatools.fsm.annotations.FSM;
 import ru.yandex.qatools.fsm.annotations.Transit;
 import ru.yandex.qatools.fsm.annotations.Transitions;
@@ -37,6 +18,7 @@ import static ru.yandex.qatools.camelot.api.Constants.Headers.UUID;
 
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
 @Aggregate
 @FSM(start = CounterState.class)
@@ -110,6 +92,9 @@ public class AggregatorWithContext {
 
     @PluginComponent
     public InjectableComponent injectableComponent;
+
+    @PluginComponent(impl = InjectableInterfaceImpl.class)
+    public InjectableInterface injectableInterface;
 
     @AggregationKey
     public String byUuid(Object event) {

--- a/camelot-test/src/main/java/ru/yandex/qatools/camelot/test/core/TestContextInjector.java
+++ b/camelot-test/src/main/java/ru/yandex/qatools/camelot/test/core/TestContextInjector.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
 public class TestContextInjector<P> extends PluginContextInjectorImpl<P> implements PluginContextInjector<P> {
     private final Map<Class, Class> overridenComponents = new HashMap<>();
@@ -36,22 +37,28 @@ public class TestContextInjector<P> extends PluginContextInjectorImpl<P> impleme
         injectOverridenComponents(pluginObj, context, exchange);
     }
 
-    private void injectOverridenComponents(Object pluginObj, final PluginContext context, final Exchange exchange) {
+    private void injectOverridenComponents(final Object pluginObj, final PluginContext context, final Exchange exchange) {
         try {
             final Map<Class, Object> components = new HashMap<>();
             injectField(pluginObj.getClass(), PluginComponent.class, pluginObj, new FieldListener<Object>() {
                 @Override
                 public Object found(Field field, AnnotationInfo info) throws Exception {
-                    final Class<?> type = (overridenComponents.containsKey(field.getType())) ?
-                            overridenComponents.get(field.getType()) : field.getType();
-                    try {
-                        if (!components.containsKey(type)) {
+
+                    final Class<?> type = overridenComponents.get(field.getType());
+                    if (type == null) {
+                        return field.get(pluginObj);
+                    }
+
+                    if (!components.containsKey(type)) {
+                        try {
                             final Object instance = type.newInstance();
                             injectComponents(instance, context, exchange);
                             components.put(type, instance);
+                        } catch (Exception e) {
+                            LOGGER.warn(String.format("Failed to inject plugin component into field %s!",
+                                    field.getName()), e);
+                            return null;
                         }
-                    } catch (Exception e) {
-                        LOGGER.warn(String.format("Failed to inject plugin component into field %s!", field.getName()), e);
                     }
                     return components.get(type);
                 }

--- a/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/CamelotTestRunnerCustomTest.java
+++ b/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/CamelotTestRunnerCustomTest.java
@@ -55,8 +55,8 @@ public class CamelotTestRunnerCustomTest {
     public void testRoute() throws Exception {
         final String uuid = randomUUID().toString();
         helper.send("test", UUID, uuid);
-        verify(prcMock, timeout(TIMEOUT)).onNodeEvent(eq("test"));
-        verify(aggMock, timeout(TIMEOUT)).onNodeEvent(any(TestState.class), eq(STATE_MESSAGE));
+        verify(prcMock, timeout(TIMEOUT)).onEvent(eq("test"));
+        verify(aggMock, timeout(TIMEOUT)).onEvent(any(TestState.class), eq(STATE_MESSAGE));
         verify(sender, timeout(TIMEOUT)).send(any(TestState.class));
 
         assertThat("State with uuid must exist", stateStorage.get(TestState.class, uuid),

--- a/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/CamelotTestRunnerWithTimerTest.java
+++ b/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/CamelotTestRunnerWithTimerTest.java
@@ -11,10 +11,10 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
-import static ru.yandex.qatools.matchers.decorators.MatcherDecorators.should;
-import static ru.yandex.qatools.matchers.decorators.TimeoutWaiter.timeoutHasExpired;
 import static ru.yandex.qatools.camelot.api.Constants.Headers.UUID;
 import static ru.yandex.qatools.camelot.test.Matchers.containStateFor;
+import static ru.yandex.qatools.matchers.decorators.MatcherDecorators.should;
+import static ru.yandex.qatools.matchers.decorators.TimeoutWaiter.timeoutHasExpired;
 
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
@@ -44,8 +44,8 @@ public class CamelotTestRunnerWithTimerTest {
     public void testRoute() throws Exception {
         helper.send("test", UUID, KEY);
 
-        verify(prcMock, timeout(TIMEOUT).times(1)).onNodeEvent(eq("test"));
-        verify(aggMock, timeout(TIMEOUT).times(1)).onNodeEvent(any(TestState.class), eq("testprocessedtestValue"));
+        verify(prcMock, timeout(TIMEOUT).times(1)).onEvent(eq("test"));
+        verify(aggMock, timeout(TIMEOUT).times(1)).onEvent(any(TestState.class), eq("testprocessedtestValue"));
 
         assertThat(stateStorage, should(containStateFor(KEY))
                 .whileWaitingUntil(timeoutHasExpired(TIMEOUT)));

--- a/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/SomeInterface.java
+++ b/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/SomeInterface.java
@@ -1,8 +1,7 @@
 package ru.yandex.qatools.camelot.test;
 
 /**
- * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
  * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
-public class SomeComponent implements SomeInterface {
+public interface SomeInterface {
 }

--- a/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/Steps.java
+++ b/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/Steps.java
@@ -16,6 +16,7 @@ import static ru.yandex.qatools.matchers.decorators.MatcherDecorators.should;
 
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
 public class Steps {
     private static final int TIMEOUT = 3000;
@@ -36,8 +37,11 @@ public class Steps {
     @ClientSenderMock(TestAggregator.class)
     ClientMessageSender sender;
 
-    @ClientSenderMock(value = TestAggregator.class, topic = "test")
-    ClientMessageSender senderTopic;
+    @ClientSenderMock(value = TestAggregator.class, topic = "someComponent")
+    ClientMessageSender senderComponentTopic;
+
+    @ClientSenderMock(value = TestAggregator.class, topic = "someInterface")
+    ClientMessageSender senderInterfaceTopic;
 
     @Resource(TestProcessor.class)
     TestResource testResource;
@@ -46,10 +50,11 @@ public class Steps {
         helper.send("test4", UUID, "uuid1");
         helper.send("test4", UUID, "uuid2");
 
-        verify(prcMock, timeout(TIMEOUT).times(2)).onNodeEvent(eq("test4"));
-        verify(aggMock, timeout(TIMEOUT).times(2)).onNodeEvent(any(TestState.class), eq(CHECK_VALUE));
+        verify(prcMock, timeout(TIMEOUT).times(2)).onEvent(eq("test4"));
+        verify(aggMock, timeout(TIMEOUT).times(2)).onEvent(any(TestState.class), eq(CHECK_VALUE));
         verify(sender, timeout(TIMEOUT).times(2)).send(any(TestState.class));
-        verify(senderTopic, timeout(TIMEOUT).times(2)).send(eq(SomeComponent.class.getName()));
+        verify(senderComponentTopic, timeout(TIMEOUT).times(2)).send(eq(SomeComponent.class.getName()));
+        verify(senderInterfaceTopic, timeout(TIMEOUT).times(2)).send(eq(SomeComponent.class.getName()));
 
         verify(aggMock, timeout(5000).never()).resetState(any(TestState.class));
 

--- a/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/TestAggregator.java
+++ b/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/TestAggregator.java
@@ -1,14 +1,15 @@
 package ru.yandex.qatools.camelot.test;
 
+import ru.yandex.qatools.camelot.api.ClientMessageSender;
 import ru.yandex.qatools.camelot.api.annotations.*;
 import ru.yandex.qatools.fsm.annotations.*;
-import ru.yandex.qatools.camelot.api.ClientMessageSender;
 
 import static jodd.util.StringUtil.isEmpty;
 import static ru.yandex.qatools.camelot.api.Constants.Headers.UUID;
 
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
+ * @author Innokenty Shuvalov (mailto: innokenty@yandex-team.ru)
  */
 @Filter(instanceOf = {Float.class, String.class})
 @Aggregate
@@ -21,11 +22,17 @@ public class TestAggregator {
     @ClientSender
     ClientMessageSender sender;
 
-    @ClientSender(topic = "test")
-    ClientMessageSender senderTopic;
+    @ClientSender(topic = "someComponent")
+    ClientMessageSender senderComponentTopic;
+
+    @ClientSender(topic = "someInterface")
+    ClientMessageSender senderInterfaceTopic;
 
     @PluginComponent
     SomeComponent someComponent;
+
+    @PluginComponent(impl = SomeComponent.class)
+    SomeInterface someInterface;
 
     @ConfigValue("camelot-test.property.mustExists")
     String mustExistProperty = null;
@@ -36,7 +43,7 @@ public class TestAggregator {
     }
 
     @OnTransit
-    public void onNodeEvent(TestState state, String event) {
+    public void onEvent(TestState state, String event) {
         if (isEmpty(mustExistProperty)) {
             throw new RuntimeException("Property must exist!");
         }
@@ -45,7 +52,8 @@ public class TestAggregator {
         }
         state.setMessage(event);
         sender.send(state);
-        senderTopic.send(someComponent.getClass().getName());
+        senderComponentTopic.send(someComponent.getClass().getName());
+        senderInterfaceTopic.send(someInterface.getClass().getName());
     }
 
     @OnTransit

--- a/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/TestProcessor.java
+++ b/camelot-test/src/test/java/ru/yandex/qatools/camelot/test/TestProcessor.java
@@ -11,7 +11,7 @@ public class TestProcessor {
     String property = "";
 
     @Processor
-    public String onNodeEvent(String event) {
+    public String onEvent(String event) {
         return event + "processed" + property;
     }
 


### PR DESCRIPTION
Add option to use PluginComponent  annotation as follows:
```
public class SomeComponent implements SomeInterface {
}

public class AnotherComponent implements SomeInterface {
}

public class SomePlugin {
    @PluginComponent(impl = SomeComponent.class)
    SomeInterface someInterface;
}

@RunWith(CamelotTestRunner.class)
@CamelotTestConfig(components = {
    @OverrideComponent(from = SomeInterface.class, to = AnotherComponent.class)
})
public class SomePluginTest {
}

```