### PR TITLE
extract property bean declarations in camelot-processing-context

### DIFF
--- a/camelot-core/src/main/resources/camelot-processing-context.xml
+++ b/camelot-core/src/main/resources/camelot-processing-context.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-            http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-            http://camel.apache.org/schema/spring
-            http://camel.apache.org/schema/spring/camel-spring.xsd
-            http://www.springframework.org/schema/context
-            http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
     <!-- Beans -->
+
+    <bean id="contextInjector" class="ru.yandex.qatools.camelot.core.impl.PluginContextInjectorImpl"/>
+    <bean id="resourceBuilder" class="ru.yandex.qatools.camelot.core.builders.SpringPluginResourceBuilder"/>
+    <bean id="appConfig" class="ru.yandex.qatools.camelot.core.impl.AppConfigSpringProperties"/>
+
+    <bean id="pluginInitializer" class="ru.yandex.qatools.camelot.core.impl.PluginInitializerWithHazelcastImpl">
+        <constructor-arg name="hazelcastInstance" ref="hazelcastInstance"/>
+    </bean>
+
     <bean id="processingEngine" class="ru.yandex.qatools.camelot.core.impl.ProcessingEngineImpl" init-method="init">
         <constructor-arg name="configResources" value="${plugins.config.path}"/>
         <constructor-arg name="camelContext" ref="camelotCamelContext"/>
@@ -19,23 +22,14 @@
         <constructor-arg name="outputUri" value="ref:events.output"/>
         <property name="scheduler" ref="scheduler"/>
         <property name="buildersFactory" ref="${camelot.factory}"/>
-        <property name="contextInjector">
-            <bean class="ru.yandex.qatools.camelot.core.impl.PluginContextInjectorImpl"/>
-        </property>
-        <property name="resourceBuilder">
-            <bean class="ru.yandex.qatools.camelot.core.builders.SpringPluginResourceBuilder"/>
-        </property>
-        <property name="appConfig">
-            <bean class="ru.yandex.qatools.camelot.core.impl.AppConfigSpringProperties"/>
-        </property>
-        <property name="pluginInitializer">
-            <bean class="ru.yandex.qatools.camelot.core.impl.PluginInitializerWithHazelcastImpl">
-                <constructor-arg name="hazelcastInstance" ref="hazelcastInstance"/>
-            </bean>
-        </property>
+        <property name="contextInjector" ref="contextInjector"/>
+        <property name="resourceBuilder" ref="resourceBuilder"/>
+        <property name="appConfig" ref="appConfig"/>
+        <property name="pluginInitializer" ref="pluginInitializer"/>
     </bean>
 
     <!-- ThreadPool profiles -->
+
     <bean id="camelotDefaultProfile" class="org.apache.camel.spi.ThreadPoolProfile">
         <property name="id" value="camelotDefaultProfile"/>
         <property name="defaultProfile" value="true"/>
@@ -53,6 +47,5 @@
         <property name="poolSize" value="${camelot.threadpool.multicast.size}"/>
         <property name="maxPoolSize" value="${camelot.threadpool.multicast.maxSize}"/>
     </bean>
-
 
 </beans>


### PR DESCRIPTION
add a possibility to import the whole context and override only one property