### PR TITLE
allow to build plugin dashboards only via plugin className

### DIFF
--- a/camelot-web/src/main/java/ru/yandex/qatools/camelot/core/web/ViewHelper.java
+++ b/camelot-web/src/main/java/ru/yandex/qatools/camelot/core/web/ViewHelper.java
@@ -51,17 +51,15 @@ public class ViewHelper {
     /**
      * Renders the plugin's dashboard
      */
-    public String renderPluginDashboard(String pluginId) {
-        final PluginContext config = pluginsService.getPluginContext(pluginId);
-        return renderPluginTemplate(pluginId, config.getDashboardPath());
+    public String renderPluginDashboard(PluginContext context) {
+        return renderPluginTemplate(context, context.getDashboardPath());
     }
 
     /**
      * Renders the plugin's widget
      */
-    public String renderPluginWidgetContent(String pluginId) {
-        final PluginContext config = pluginsService.getPluginContext(pluginId);
-        return renderPluginTemplate(pluginId, config.getWidgetPath());
+    public String renderPluginWidgetContent(PluginContext context) {
+        return renderPluginTemplate(context, context.getWidgetPath());
     }
 
     /**
@@ -85,8 +83,7 @@ public class ViewHelper {
     /**
      * Renders the plugin template file with context
      */
-    private String renderPluginTemplate(String pluginId, String templatePath) {
-        final PluginContext context = pluginsService.getPluginContext(pluginId);
+    private String renderPluginTemplate(PluginContext context, String templatePath) {
         if (!isEmpty(templatePath)) {
             try {
                 return renderSource(
@@ -99,7 +96,7 @@ public class ViewHelper {
                 return "Failed to render plugin template: " + e.getMessage();
             }
         }
-        return "No such template found for plugin '" + pluginId + "' (" + templatePath + ")!";
+        return "No such template found for plugin '" + context.getId() + "' (" + templatePath + ")!";
     }
 
     /**

--- a/camelot-web/src/main/java/ru/yandex/qatools/camelot/web/PluginIndexResource.java
+++ b/camelot-web/src/main/java/ru/yandex/qatools/camelot/web/PluginIndexResource.java
@@ -3,7 +3,7 @@ package ru.yandex.qatools.camelot.web;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import ru.yandex.qatools.camelot.config.Plugin;
+import ru.yandex.qatools.camelot.config.PluginWebContext;
 import ru.yandex.qatools.camelot.core.WebfrontEngine;
 import ru.yandex.qatools.camelot.core.web.ViewHelper;
 
@@ -29,8 +29,8 @@ public class PluginIndexResource extends BasicViewResource {
         return "Plugin " + pluginId;
     }
 
-    public Plugin getPlugin() {
-        return pluginsService.getPlugin(pluginId);
+    public PluginWebContext getPlugin() {
+        return pluginsService.getPluginContext(pluginId);
     }
 
     public ViewHelper getViewHelper() {

--- a/camelot-web/src/main/webapp/WEB-INF/views/IndexResource.index.jade
+++ b/camelot-web/src/main/webapp/WEB-INF/views/IndexResource.index.jade
@@ -9,6 +9,6 @@ div(ng-app="camelotDashboard")
         - pContext = plugin.getContext()
         if pContext.getWidgetPath() != null
             script(type="text/ng-template", id="#{plugin.getId()}")
-                != helper.renderPluginWidgetContent(plugin.getId())
+                != helper.renderPluginWidgetContent(pContext)
     script(type="text/ng-template", id="settings")
         != view.render("blocks/SettingsWidget.jade")

--- a/camelot-web/src/main/webapp/WEB-INF/views/PluginIndexResource.index.jade
+++ b/camelot-web/src/main/webapp/WEB-INF/views/PluginIndexResource.index.jade
@@ -2,4 +2,5 @@
 - plugin = this.getPlugin()
 script
     angular.module('camelotUtil').value('pluginId', '#{plugin.getId()}')
-!= helper.renderPluginDashboard(this.getPluginId())
+div(ng-app="#{plugin.pluginClass}.dashboard")
+    != helper.renderPluginDashboard(plugin)

--- a/camelot-web/src/test/java/ru/yandex/qatools/camelot/core/web/ViewHelperTest.java
+++ b/camelot-web/src/test/java/ru/yandex/qatools/camelot/core/web/ViewHelperTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import ru.yandex.qatools.camelot.config.PluginContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -24,18 +25,22 @@ public class ViewHelperTest {
 
     @Test
     public void testLifecycle() {
-        assertEquals("lifecycle", viewHelper.renderPluginDashboard("lifecycle"));
-        assertTrue(viewHelper.renderPluginWidgetContent("lifecycle").contains("No such"));
+        assertEquals("lifecycle", viewHelper.renderPluginDashboard(getContext("lifecycle")));
+        assertTrue(viewHelper.renderPluginWidgetContent(getContext("lifecycle")).contains("No such"));
     }
 
     @Test
     public void testAllSkipped() {
-        assertEquals("all-skipped", viewHelper.renderPluginDashboard("all-skipped"));
-        assertEquals(PluginViewHelper.class.getSimpleName(), viewHelper.renderPluginWidgetContent("all-skipped"));
+        assertEquals("all-skipped", viewHelper.renderPluginDashboard(getContext("all-skipped")));
+        assertEquals(PluginViewHelper.class.getSimpleName(), viewHelper.renderPluginWidgetContent(getContext("all-skipped")));
     }
 
     @Test
     public void testTestStarted() {
-        assertEquals("<p>Hello, World!</p>Hey", viewHelper.renderPluginDashboard("test-started"));
+        assertEquals("<p>Hello, World!</p>Hey", viewHelper.renderPluginDashboard(getContext("test-started")));
+    }
+
+    private PluginContext getContext(String pluginId) {
+        return viewHelper.pluginsService.getPluginContext(pluginId);
     }
 }


### PR DESCRIPTION
This change prohibits building plugin dashboards using plugin id's specified in ```camelot.xml``` instead of java classNames of the plugins. That is a subject for discussion but so far it the the proposed way of building front-end. At least because of the fact that front-end source code needs to be located under a directory called in accordance with the plugin java package.