### PR TITLE
remove logging of 'Lock is still not available' line

### DIFF
--- a/camelot-core/src/main/java/ru/yandex/qatools/camelot/hazelcast/HazelcastAggregationRepository.java
+++ b/camelot-core/src/main/java/ru/yandex/qatools/camelot/hazelcast/HazelcastAggregationRepository.java
@@ -213,7 +213,6 @@ public class HazelcastAggregationRepository
         long startedTime = currentTimeMillis();
         boolean timeout = false;
         while (!map.tryLock(key, lockWaitHeartbeatSec, SECONDS) && !timeout) {
-            debug("Lock is still not available, waiting for key '{}'", key);
             timeout = isTimePassedSince(SECONDS.toMillis(waitForLockSec), startedTime);
         }
         return !timeout;


### PR DESCRIPTION
This log line doesn't really mean anything:
* it's an absolutely normal behavior
* you can not really anything by this line